### PR TITLE
Fix dateformat value in SQL-Query app_config

### DIFF
--- a/database/2.3.2_to_2.3.3.sql
+++ b/database/2.3.2_to_2.3.3.sql
@@ -2,5 +2,5 @@ ALTER TABLE `ospos_suppliers`
    ADD COLUMN `agency_name` VARCHAR(255) NOT NULL;
 
 INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
-   ('dateformat', 'm-d-Y'),
+   ('dateformat', 'm/d/Y'),
    ('timeformat', 'H:i:s');

--- a/database/database.sql
+++ b/database/database.sql
@@ -68,7 +68,7 @@ INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
 ('default_sales_discount', '0'),
 ('lines_per_page', '25'),
 ('show_total_discount', '1'),
-('dateformat', 'm-d-Y'),
+('dateformat', 'm/d/Y'),
 ('timeformat', 'H:i:s'),
 ('currency_symbol', '$');
 


### PR DESCRIPTION
I got an error when trying to edit a sale from the detailed sales-report:
It always said "please enter a valid date" because the date format was d-m-Y. I looked into the settings, changed the format and noticed that there it is d/m/Y which was working fine.
I changed the corresponding SQL-Queries so noone who updates or installs OSPOS and tries to edit the date of a sale gets this error...