### PR TITLE
#165 Fix invoice wrong date on sale completion

### DIFF
--- a/application/controllers/sales.php
+++ b/application/controllers/sales.php
@@ -333,7 +333,7 @@ class Sales extends Secure_area
 		$data['discount']=$this->sale_lib->get_discount();
 		$data['receipt_title']=$this->lang->line('sales_receipt');
 		$data['transaction_time']= date($this->config->item('dateformat').' '.$this->config->item('timeformat'));
-		$data['transaction_date']= date($this->config->item('dateformat'), strtotime($data['transaction_time']));
+		$data['transaction_date']= date($this->config->item('dateformat'));
 		$data['show_stock_locations']=$this->Stock_location->show_locations('sales');
 		$customer_id=$this->sale_lib->get_customer();
 		$employee_id=$this->Employee->get_logged_in_employee_info()->person_id;

--- a/application/views/sales/invoice.php
+++ b/application/views/sales/invoice.php
@@ -53,7 +53,7 @@ if (isset($error_message))
             
             <tr>
                 <td class="meta-head"><?php echo $this->lang->line('sales_amount_due'); ?></td>
-                <td><div class="due"><?php echo to_currency($total); ?></div></td>
+                <td><textarea rows="5" cols="6"><?php echo to_currency($total); ?></textarea></td>
             </tr>
 			
         </table>


### PR DESCRIPTION
Fix to invoice wrong date on sale completion and fixed the wrong font for "amount due" shown in the invoice.