### PR TITLE
Fixed Severity: Notice Message: Only variable references should be returned by reference Filename: core/Common.php Line Number: 257

### DIFF
--- a/application/helpers/currency_helper.php
+++ b/application/helpers/currency_helper.php
@@ -4,7 +4,7 @@ function to_currency($number,$escape=FALSE)
 {
 	$CI =& get_instance();
 	$currency_symbol = $CI->config->item('currency_symbol') ? $CI->config->item('currency_symbol') : '$';
-	$currency_symbol = $currency_symbol == '$' && $escape ? '\$' : '$'; 
+	$currency_symbol = $currency_symbol == '$' && $escape ? '\$' : $currency_symbol; 
 	$thousands_separator = $CI->config->item('thousands_separator') ? $CI->config->item('thousands_separator') : '';
 	$decimal_point = $CI->config->item('decimal_point') ? $CI->config->item('decimal_point') : '.';
 	if($number >= 0)

--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -253,8 +253,8 @@ if ( ! function_exists('get_config'))
 				}
 			}
 		}
-
-		return $_config[0] =& $config;
+		$_config[0] =& $config;
+		return $_config[0];
 	}
 }
 


### PR DESCRIPTION
Severity: Notice Message: Only variable references should be returned by reference Filename: core/Common.php Line Number: 257