### PR TITLE
Restrict inventory reports to stock items

### DIFF
--- a/application/libraries/Sale_lib.php
+++ b/application/libraries/Sale_lib.php
@@ -407,7 +407,7 @@ class Sale_lib
 		{
 			$item_info = $this->CI->Item->get_info_by_id_or_number($item_id);
 
-			if ($item_info->stock_type === 0) {
+			if ($item_info->stock_type == '0') {
 				$item_quantity = $this->CI->Item_quantity->get_item_quantity($item_id, $item_location)->quantity;
 				$quantity_added = $this->get_quantity_already_added($item_id, $item_location);
 

--- a/application/libraries/Sale_lib.php
+++ b/application/libraries/Sale_lib.php
@@ -3,7 +3,6 @@
 class Sale_lib
 {
 	private $CI;
-	private $line_sequence_options = array('0' => 'Standard', '1' => 'Entry', '2' => 'Group by Type', '3' => 'Group by Category');
 
 	public function __construct()
 	{

--- a/application/models/Sale.php
+++ b/application/models/Sale.php
@@ -688,19 +688,19 @@ class Sale extends CI_Model
 		$this->db->where('sale_id', $sale_id);
 
 		// Entry sequence (this will render kits in the expected sequence)
-		if($this->config->item('line_sequence') == '1')
+		if($this->config->item('line_sequence') == '0')
 		{
 			$this->db->order_by('line', 'asc');
 		}
 		// Group by Stock Type (nonstock first - type 1, stock next - type 0)
-		elseif($this->config->item('line_sequence') == '2')
+		elseif($this->config->item('line_sequence') == '1')
 		{
 			$this->db->order_by('stock_type', 'desc');
 			$this->db->order_by('sales_items.description', 'asc');
 			$this->db->order_by('items.name', 'asc');
 		}
 		// Group by Item Category
-		elseif($this->config->item('line_sequence') == '3')
+		elseif($this->config->item('line_sequence') == '2')
 		{
 			$this->db->order_by('category', 'asc');
 			$this->db->order_by('sales_items.description', 'asc');

--- a/application/models/reports/Inventory_low.php
+++ b/application/models/reports/Inventory_low.php
@@ -27,7 +27,7 @@ class Inventory_low extends Report
 		$this->db->join('stock_locations', 'item_quantities.location_id = stock_locations.location_id');
 		$this->db->where('items.deleted', 0);
 		$this->db->where('stock_locations.deleted', 0);
-		$this->db->where('item_quantities.quantity <= items.reorder_level');
+		$this->db->where('items.stock_type', 0);
 		$this->db->order_by('items.name');				
 
 		return $this->db->get()->result_array();

--- a/application/models/reports/Inventory_summary.php
+++ b/application/models/reports/Inventory_summary.php
@@ -28,6 +28,7 @@ class Inventory_summary extends Report
 		$this->db->join('item_quantities AS item_quantities', 'items.item_id = item_quantities.item_id');
 		$this->db->join('stock_locations AS stock_locations', 'item_quantities.location_id = stock_locations.location_id');
 		$this->db->where('items.deleted', 0);
+		$this->db->where('items.stock_type', 0);
 		$this->db->where('stock_locations.deleted', 0);
 
 		// should be corresponding to values Inventory_summary::getItemCountDropdownArray() returns...

--- a/application/views/configs/invoice_config.php
+++ b/application/views/configs/invoice_config.php
@@ -66,13 +66,6 @@
 				</div>
 			</div>
 
-			<div class="form-group form-group-sm">
-				<?php echo form_label($this->lang->line('config_line_sequence'), 'line_sequence', array('class' => 'control-label col-xs-2')); ?>
-				<div class='col-xs-2'>
-					<?php echo form_dropdown('line_sequence', $line_sequence_options, $this->config->item('line_sequence'), array('class' => 'form-control input-sm')); ?>
-				</div>
-			</div>
-
 			<?php echo form_submit(array(
 				'name' => 'submit_form',
 				'id' => 'submit_form',


### PR DESCRIPTION
With the introduction of the new stock type field (stocked or not) it makes sense that the inventory reports now filter out non-stock items.  This pull request will change the inventory reports (Low Inventory and Inventory Summary) to include only stocked items.