### PR TITLE
Restore reorder level check for low inventory report

### DIFF
--- a/application/models/reports/Inventory_low.php
+++ b/application/models/reports/Inventory_low.php
@@ -28,7 +28,8 @@ class Inventory_low extends Report
 		$this->db->where('items.deleted', 0);
 		$this->db->where('stock_locations.deleted', 0);
 		$this->db->where('items.stock_type', 0);
-		$this->db->order_by('items.name');				
+		$this->db->where('item_quantities.quantity <= items.reorder_level');
+		$this->db->order_by('items.name');
 
 		return $this->db->get()->result_array();
 	}


### PR DESCRIPTION
@odiea is correct again.  I accidentally "replaced" instead of "inserted".  So this restores the missing check against the reorder level.