### PR TITLE
This will fix the issue with the PHP error when adding a new item kit…

### DIFF
--- a/application/controllers/Item_kits.php
+++ b/application/controllers/Item_kits.php
@@ -89,6 +89,7 @@ class Item_kits extends Secure_Controller
 		{
 			$info->price_option = '0';
 			$info->print_option = '0';
+			$info->kit_item_id = 0;
 		}
 		foreach(get_object_vars($info) as $property => $value)
 		{

--- a/database/3.0.2_to_3.1.0.sql
+++ b/database/3.0.2_to_3.1.0.sql
@@ -20,6 +20,9 @@ ALTER TABLE `ospos_sales_items`
 ALTER TABLE `ospos_sales_suspended_items`
  ADD COLUMN `print_option` TINYINT(2) NOT NULL DEFAULT 0;
 
+INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
+('line_sequence', '0');
+
 -- alter pic_id field, to rather contain a file name
 
 ALTER TABLE `ospos_items` CHANGE `pic_id` `pic_filename` VARCHAR(255);

--- a/database/database.sql
+++ b/database/database.sql
@@ -44,6 +44,7 @@ INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
 ('receipt_show_description', '1'),
 ('receipt_show_serialnumber', '1'),
 ('invoice_enable', '1'),
+('line_sequence', '0'),
 ('recv_invoice_format', '$CO'),
 ('sales_invoice_format', '$CO'),
 ('invoice_email_message', 'Dear $CU, In attachment the receipt for sale $INV'),

--- a/database/tables.sql
+++ b/database/tables.sql
@@ -44,6 +44,7 @@ INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
 ('receipt_show_description', '1'),
 ('receipt_show_serialnumber', '1'),
 ('invoice_enable', '1'),
+('line_sequence', '0'),
 ('recv_invoice_format', '$CO'),
 ('sales_invoice_format', '$CO'),
 ('invoice_email_message', 'Dear $CU, In attachment the receipt for sale $INV'),


### PR DESCRIPTION
Once I set the environment to development (instead of production) the PHP error magically appeared.  My recommendation is to always run in production mode.

However, if you prefer you can install this commit and it will fix the issue.  ;-)

This also includes the fix to initialize the new line_sequence config variable to 0 for Entry Sequence.