### PR TITLE
Fixed bug sales data preview of day

### DIFF
--- a/application/views/partial/daterangepicker.php
+++ b/application/views/partial/daterangepicker.php
@@ -106,9 +106,8 @@
 	{
 ?>
 		$('#daterangepicker').css("width","305");
-		var start_date = "<?php echo date('Y-m-d H:i:s')?>";
-		var end_date = "<?php echo date('Y-m-d H:i:s')?>";
-
+		var start_date = "<?php echo date('Y-m-d H:i:s',mktime(0,0,0,date("m"),date("d"),date("Y")))?>";
+		var end_date = "<?php echo date('Y-m-d H:i:s',mktime(23,59,59,date("m"),date("d"),date("Y")))?>";
 		$('#daterangepicker').daterangepicker({
 			"ranges": {
 				"<?php echo $this->lang->line("datepicker_today"); ?>": [
@@ -198,9 +197,9 @@
 		    "timePickerSeconds": true,
 			"alwaysShowCalendars": true,
 			"startDate": "<?php echo date($this->config->item('dateformat')." ".$this->config->item('timeformat'),mktime(0,0,0,date("m"),date("d"),date("Y")));?>",
-			"endDate": "<?php echo date($this->config->item('dateformat')." ".$this->config->item('timeformat'),mktime(23,59,59,date("m"),date("d"),date("Y"))-1);?>",
+			"endDate": "<?php echo date($this->config->item('dateformat')." ".$this->config->item('timeformat'),mktime(23,59,59,date("m"),date("d"),date("Y")));?>",
 			"minDate": "<?php echo date($this->config->item('dateformat')." ".$this->config->item('timeformat'),mktime(0,0,0,01,01,2010));?>",
-			"maxDate": "<?php echo date($this->config->item('dateformat')." ".$this->config->item('timeformat'),mktime(23,59,59,date("m"),date("d"),date("Y"))-1);?>"
+			"maxDate": "<?php echo date($this->config->item('dateformat')." ".$this->config->item('timeformat'),mktime(23,59,59,date("m"),date("d"),date("Y")));?>"
 		}, function(start, end, label) {
 			start_date = start.format('YYYY-MM-DD HH:mm:ss');
 			end_date = end.format('YYYY-MM-DD HH:mm:ss');

--- a/database/2.4_to_3.0.sql
+++ b/database/2.4_to_3.0.sql
@@ -69,7 +69,8 @@ INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
 ('theme', 'flatly'),
 ('statistics', '1'),
 ('language', 'english'),
-('language_code', 'en');
+('language_code', 'en'),
+('date_or_time_format','');
 
 
 -- add messages (SMS) module and permissions

--- a/database/database.sql
+++ b/database/database.sql
@@ -82,7 +82,8 @@ INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
 ('theme', 'flatly'),
 ('statistics', '1'),
 ('language', 'english'),
-('language_code', 'en');
+('language_code', 'en'),
+('date_or_time_format','');
 
 
 -- --------------------------------------------------------


### PR DESCRIPTION
Fixed bug sales data preview of day when field date or time is checked into config location tab, and add support to database.sql and migration script from 3.0.2 to 3.1.0 for set date_or_time_format value