### PR TITLE
Fix database creation duplicate config value error

### DIFF
--- a/database/database.sql
+++ b/database/database.sql
@@ -92,7 +92,6 @@ INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
 ('language_code', 'en'),
 ('date_or_time_format',''),
 ('customer_reward_enable',''),
-('customer_sales_tax_support', '0'),
 ('default_origin_tax_code', ''),
 ('cash_decimals', '2');
 

--- a/database/tables.sql
+++ b/database/tables.sql
@@ -92,7 +92,6 @@ INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
 ('language_code', 'en'),
 ('date_or_time_format',''),
 ('customer_reward_enable',''),
-('customer_sales_tax_support', '0'),
 ('default_origin_tax_code', ''),
 ('cash_decimals', '2');
 


### PR DESCRIPTION
This removes the duplicate entry  on the new customer_sales_tax_support configuration value.