### PR TITLE
Make Sales Tax Code uppercase

### DIFF
--- a/application/views/configs/general_config.php
+++ b/application/views/configs/general_config.php
@@ -77,7 +77,7 @@
 					<?php echo form_input(array(
 						'name' => 'default_origin_tax_code',
 						'id' => 'default_origin_tax_code',
-						'class' => 'form-control input-sm',
+						'class' => 'form-control input-sm text-uppercase',
 						'value'=>$this->config->item('default_origin_tax_code'))); ?>
                 </div>
             </div>

--- a/application/views/taxes/form.php
+++ b/application/views/taxes/form.php
@@ -10,7 +10,7 @@
 				<?php echo form_input(array(
 						'name'=>'tax_code',
 						'id'=>'tax_code',
-						'class'=>'form-control input-sm',
+						'class'=>'form-control input-sm text-uppercase',
 						'value'=>$tax_code)
 						);?>
 			</div>


### PR DESCRIPTION
I meant to do this earlier, but it was low priority.  Since the tax code is supposed to be a code, by convention it should be uppercase.  It wasn't until I was showing a user how to add a tax that I realized that I had to programmatically force it to uppercase.