### PR TITLE
Fix the line total extension error when receiving received item.

### DIFF
--- a/application/libraries/Receiving_lib.php
+++ b/application/libraries/Receiving_lib.php
@@ -226,6 +226,7 @@ class Receiving_lib
 		if($itemalreadyinsale)
 		{
 			$items[$updatekey]['quantity'] += $quantity;
+			$items[$updatekey]['total'] = $this->get_item_total($items[$updatekey]['quantity'], $price, $discount);
 		}
 		else
 		{


### PR DESCRIPTION
This will address the issue reported on #1233.  When the same item was received multiple times for the same receipt, the quantity was being incremented but the extended total wasn't being updated.