### PR TITLE
Fix undefined table_status error in Sale.php

### DIFF
--- a/application/models/Sale.php
+++ b/application/models/Sale.php
@@ -522,6 +522,10 @@ class Sale extends CI_Model
 				$table_status = 0;
 			}
 		}
+		else
+		{
+			$table_status = 0;
+		}
 
 		$sales_data = array(
 			'sale_time'		 => date('Y-m-d H:i:s'),


### PR DESCRIPTION
This has resolved the error for me with the undefined table_status which occurs when the dinner table feature is not enabled.  I default the table status to '0' and I'm just assuming that the value is irrelevant when the dinner table feature is not enabled but if not then '0' will be  acceptable.