### PR TITLE
Fix #1340 - failure to discard quotes

### DIFF
--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -574,6 +574,7 @@ class Sales extends Secure_Controller
 				$data['sale_status'] = '1'; // Suspended
 
 				$data['sale_id_num'] = $this->Sale->save($data['sale_status'], $data['cart'], $customer_id, $employee_id, $data['comments'], $invoice_number, $quote_number, $data['payments'], $data['dinner_table'], $data['taxes']);
+				$this->sale_lib->set_suspended_id($data['sale_id_num']);
 
 				$data['cart'] = $this->sale_lib->sort_and_filter_cart($data['cart']);
 


### PR DESCRIPTION
This resolves the issue with the suspended sale or quote not being removed from the sales tables.