### PR TITLE
Improve sale status reporting

### DIFF
--- a/application/language/en/reports_lang.php
+++ b/application/language/en/reports_lang.php
@@ -52,6 +52,7 @@ $lang["reports_payments_summary_report"] = "Payments Summary Report";
 $lang["reports_profit"] = "Profit";
 $lang["reports_quantity"] = "Quantity";
 $lang["reports_quantity_purchased"] = "Quantity Purchased";
+$lang["reports_quotes"] = "Quotes";
 $lang["reports_received_by"] = "Received By";
 $lang["reports_receiving_id"] = "Receiving ID";
 $lang["reports_receiving_type"] = "Receiving Type";

--- a/application/models/reports/Detailed_sales.php
+++ b/application/models/reports/Detailed_sales.php
@@ -67,6 +67,7 @@ class Detailed_sales extends Report
 	public function getData(array $inputs)
 	{
 		$this->db->select('sale_id,
+			MAX(sale_status) as sale_status,
 			MAX(sale_date) AS sale_date,
 			SUM(quantity_purchased) AS items_purchased,
 			MAX(employee_name) AS employee_name,
@@ -87,11 +88,19 @@ class Detailed_sales extends Report
 
 		if($inputs['sale_type'] == 'sales')
 		{
-			$this->db->where('quantity_purchased > 0');
+			$this->db->where('sale_status = 0 and quantity_purchased > 0');
+		}
+		elseif($inputs['sale_type'] == 'all')
+		{
+			$this->db->where('sale_status = 0');
+		}
+		elseif($inputs['sale_type'] == 'quotes')
+		{
+			$this->db->where('sale_status = 1 and quote_number IS NOT NULL');
 		}
 		elseif($inputs['sale_type'] == 'returns')
 		{
-			$this->db->where('quantity_purchased < 0');
+			$this->db->where('sale_status = 0 and quantity_purchased < 0');
 		}
 
 		$this->db->group_by('sale_id');
@@ -104,7 +113,7 @@ class Detailed_sales extends Report
 
 		foreach($data['summary'] as $key=>$value)
 		{
-			$this->db->select('name, category, quantity_purchased, item_location, serialnumber, description, subtotal, tax, total, cost, profit, discount_percent');
+			$this->db->select('name, category, quantity_purchased, item_location, serialnumber, description, subtotal, tax, total, cost, profit, discount_percent, sale_status');
 			$this->db->from('sales_items_temp');
 			$this->db->where('sale_id', $value['sale_id']);
 			$data['details'][$key] = $this->db->get()->result_array();
@@ -129,11 +138,19 @@ class Detailed_sales extends Report
 
 		if($inputs['sale_type'] == 'sales')
 		{
-			$this->db->where('quantity_purchased > 0');
+			$this->db->where('sale_status = 0 and quantity_purchased > 0');
+		}
+		elseif($inputs['sale_type'] == 'all')
+		{
+			$this->db->where('sale_status = 0');
+		}
+		elseif($inputs['sale_type'] == 'quotes')
+		{
+			$this->db->where('sale_status = 1 and quote_number IS NOT NULL');
 		}
 		elseif($inputs['sale_type'] == 'returns')
 		{
-			$this->db->where('quantity_purchased < 0');
+			$this->db->where('sale_status = 0 and quantity_purchased < 0');
 		}
 
 		return $this->db->get()->row_array();

--- a/application/models/reports/Specific_customer.php
+++ b/application/models/reports/Specific_customer.php
@@ -61,11 +61,19 @@ class Specific_customer extends Report
 
 		if($inputs['sale_type'] == 'sales')
 		{
-			$this->db->where('quantity_purchased > 0');
+			$this->db->where('sale_status = 0 and quantity_purchased > 0');
+		}
+		elseif($inputs['sale_type'] == 'all')
+		{
+			$this->db->where('sale_status = 0');
+		}
+		elseif($inputs['sale_type'] == 'quotes')
+		{
+			$this->db->where('sale_status = 1 and quote_number IS NOT NULL');
 		}
 		elseif($inputs['sale_type'] == 'returns')
 		{
-			$this->db->where('quantity_purchased < 0');
+			$this->db->where('sale_status = 0 and quantity_purchased < 0');
 		}
 
 		$this->db->group_by('sale_id');
@@ -99,11 +107,19 @@ class Specific_customer extends Report
 
 		if($inputs['sale_type'] == 'sales')
 		{
-			$this->db->where('quantity_purchased > 0');
+			$this->db->where('sale_status = 0 and quantity_purchased > 0');
+		}
+		elseif($inputs['sale_type'] == 'all')
+		{
+			$this->db->where('sale_status = 0');
+		}
+		elseif($inputs['sale_type'] == 'quotes')
+		{
+			$this->db->where('sale_status = 1 and quote_number IS NOT NULL');
 		}
 		elseif($inputs['sale_type'] == 'returns')
 		{
-			$this->db->where('quantity_purchased < 0');
+			$this->db->where('sale_status = 0 and quantity_purchased < 0');
 		}
 
 		return $this->db->get()->row_array();

--- a/application/models/reports/Specific_discount.php
+++ b/application/models/reports/Specific_discount.php
@@ -59,11 +59,19 @@ class Specific_discount extends Report
 
 		if($inputs['sale_type'] == 'sales')
 		{
-			$this->db->where('quantity_purchased > 0');
+			$this->db->where('sale_status = 0 and quantity_purchased > 0');
+		}
+		elseif($inputs['sale_type'] == 'all')
+		{
+			$this->db->where('sale_status = 0');
+		}
+		elseif($inputs['sale_type'] == 'quotes')
+		{
+			$this->db->where('sale_status = 1 and quote_number IS NOT NULL');
 		}
 		elseif($inputs['sale_type'] == 'returns')
 		{
-			$this->db->where('quantity_purchased < 0');
+			$this->db->where('sale_status = 0 and quantity_purchased < 0');
 		}
 
 		$this->db->group_by('sale_id');
@@ -97,11 +105,19 @@ class Specific_discount extends Report
 
 		if($inputs['sale_type'] == 'sales')
 		{
-			$this->db->where('quantity_purchased > 0');
+			$this->db->where('sale_status = 0 and quantity_purchased > 0');
+		}
+		elseif($inputs['sale_type'] == 'all')
+		{
+			$this->db->where('sale_status = 0');
+		}
+		elseif($inputs['sale_type'] == 'quotes')
+		{
+			$this->db->where('sale_status = 1 and quote_number IS NOT NULL');
 		}
 		elseif($inputs['sale_type'] == 'returns')
 		{
-			$this->db->where('quantity_purchased < 0');
+			$this->db->where('sale_status = 0 and quantity_purchased < 0');
 		}
 
 		return $this->db->get()->row_array();

--- a/application/models/reports/Specific_employee.php
+++ b/application/models/reports/Specific_employee.php
@@ -60,13 +60,21 @@ class Specific_employee extends Report
 		$this->db->where('employee_id', $inputs['employee_id']);
 
 		if($inputs['sale_type'] == 'sales')
-        {
-            $this->db->where('quantity_purchased > 0');
-        }
-        elseif($inputs['sale_type'] == 'returns')
-        {
-            $this->db->where('quantity_purchased < 0');
-        }
+		{
+			$this->db->where('sale_status = 0 and quantity_purchased > 0');
+		}
+		elseif($inputs['sale_type'] == 'all')
+		{
+			$this->db->where('sale_status = 0');
+		}
+		elseif($inputs['sale_type'] == 'quotes')
+		{
+			$this->db->where('sale_status = 1 and quote_number IS NOT NULL');
+		}
+		elseif($inputs['sale_type'] == 'returns')
+		{
+			$this->db->where('sale_status = 0 and quantity_purchased < 0');
+		}
 
 		$this->db->group_by('sale_id');
 		$this->db->order_by('MAX(sale_date)');
@@ -99,11 +107,19 @@ class Specific_employee extends Report
 
 		if($inputs['sale_type'] == 'sales')
 		{
-			$this->db->where('quantity_purchased > 0');
+			$this->db->where('sale_status = 0 and quantity_purchased > 0');
+		}
+		elseif($inputs['sale_type'] == 'all')
+		{
+			$this->db->where('sale_status = 0');
+		}
+		elseif($inputs['sale_type'] == 'quotes')
+		{
+			$this->db->where('sale_status = 1 and quote_number IS NOT NULL');
 		}
 		elseif($inputs['sale_type'] == 'returns')
 		{
-			$this->db->where('quantity_purchased < 0');
+			$this->db->where('sale_status = 0 and quantity_purchased < 0');
 		}
 
 		return $this->db->get()->row_array();

--- a/application/models/reports/Summary_report.php
+++ b/application/models/reports/Summary_report.php
@@ -51,7 +51,7 @@ abstract class Summary_report extends Report
 					ON sales.sale_id = sales_items_taxes.sale_id
 				INNER JOIN ' . $this->db->dbprefix('sales_items') . ' AS sales_items
 					ON sales_items.sale_id = sales_items_taxes.sale_id AND sales_items.line = sales_items_taxes.line
-				WHERE sales.sale_status = 0 AND ' . $where . '
+				WHERE ' . $where . '
 				GROUP BY sale_id, item_id, line
 			)'
 		);
@@ -92,12 +92,22 @@ abstract class Summary_report extends Report
 
 		if($inputs['sale_type'] == 'sales')
 		{
-			$this->db->where('sales_items.quantity_purchased >= 0');
+			$this->db->where('sale_status = 0 and quantity_purchased > 0');
+		}
+		elseif($inputs['sale_type'] == 'all')
+		{
+			$this->db->where('sale_status = 0');
+		}
+		elseif($inputs['sale_type'] == 'quotes')
+		{
+			$this->db->where('sale_status = 1 and quote_number IS NOT NULL');
 		}
 		elseif($inputs['sale_type'] == 'returns')
 		{
-			$this->db->where('sales_items.quantity_purchased < 0');
+			$this->db->where('sale_status = 0 and quantity_purchased < 0');
 		}
+
+
 	}
 
 	/**

--- a/application/models/reports/Summary_taxes.php
+++ b/application/models/reports/Summary_taxes.php
@@ -18,11 +18,11 @@ class Summary_taxes extends Summary_report
 	{
 		if(empty($this->config->item('date_or_time_format')))
 		{
-			$this->db->where('sale_status = 0 AND DATE(sales.sale_time) BETWEEN ' . $this->db->escape($inputs['start_date']) . ' AND ' . $this->db->escape($inputs['end_date']));
+			$this->db->where('DATE(sales.sale_time) BETWEEN ' . $this->db->escape($inputs['start_date']) . ' AND ' . $this->db->escape($inputs['end_date']));
 		}
 		else
 		{
-			$this->db->where('sale_status = 0 AND sales.sale_time BETWEEN ' . $this->db->escape(rawurldecode($inputs['start_date'])) . ' AND ' . $this->db->escape(rawurldecode($inputs['end_date'])));
+			$this->db->where('sales.sale_time BETWEEN ' . $this->db->escape(rawurldecode($inputs['start_date'])) . ' AND ' . $this->db->escape(rawurldecode($inputs['end_date'])));
 		}
 	}
 
@@ -32,11 +32,11 @@ class Summary_taxes extends Summary_report
 
 		if(empty($this->config->item('date_or_time_format')))
 		{
-			$where .= 'WHERE sale_status = 0 AND DATE(sale_time) BETWEEN ' . $this->db->escape($inputs['start_date']) . ' AND ' . $this->db->escape($inputs['end_date']);
+			$where .= 'WHERE DATE(sale_time) BETWEEN ' . $this->db->escape($inputs['start_date']) . ' AND ' . $this->db->escape($inputs['end_date']);
 		}
 		else
 		{
-			$where .= 'WHERE sale_status = 0 AND sale_time BETWEEN ' . $this->db->escape(rawurldecode($inputs['start_date'])) . ' AND ' . $this->db->escape(rawurldecode($inputs['end_date']));
+			$where .= 'WHERE sale_time BETWEEN ' . $this->db->escape(rawurldecode($inputs['start_date'])) . ' AND ' . $this->db->escape(rawurldecode($inputs['end_date']));
 		}
 
 		if($this->config->item('tax_included'))

--- a/application/views/reports/date_input.php
+++ b/application/views/reports/date_input.php
@@ -31,6 +31,7 @@ if(isset($error))
 			<div id='report_sale_type' class="col-xs-3">
 				<?php echo form_dropdown('sale_type', array('all' => $this->lang->line('reports_all'),
 				'sales' => $this->lang->line('reports_sales'),
+				'quotes' => $this->lang->line('reports_quotes'),
 				'returns' => $this->lang->line('reports_returns')), 'all', array('id'=>'input_type', 'class'=>'form-control')); ?>
 			</div>
 		<?php

--- a/application/views/reports/specific_input.php
+++ b/application/views/reports/specific_input.php
@@ -34,6 +34,7 @@ if(isset($error))
 		<div id='report_sale_type' class="col-xs-3">
 			<?php echo form_dropdown('sale_type', array('all' => $this->lang->line('reports_all'),
 				'sales' => $this->lang->line('reports_sales'),
+				'quotes' => $this->lang->line('reports_quotes'),
 				'returns' => $this->lang->line('reports_returns')), 'all', 'id="input_type" class="form-control"'); ?>
 		</div>
 	</div>


### PR DESCRIPTION
This pull request addresses the detail reports. I'll have another one later this week that addresses the summary reports.

This insure that when the reports are run for "all", "sales" or :returns" then they only include sale_type of 0. When run for a quote then it only includes a sale_type of 1. Suspended orders (non-quotes) will be excluded from the detail reports.