### PR TITLE
Display tax decimals or currency decimals for tax amounts.

### DIFF
--- a/application/helpers/locale_helper.php
+++ b/application/helpers/locale_helper.php
@@ -64,7 +64,16 @@ function to_currency_no_money($number)
 
 function to_currency_tax($number)
 {
-    return to_decimals($number, 'tax_decimals', \NumberFormatter::CURRENCY);
+	$config = get_instance()->config;
+
+    if($config->item('customer_sales_tax_support') == '1')
+    {
+		return to_decimals($number, 'currency_decimals', \NumberFormatter::CURRENCY);
+    }
+    else
+    {
+		return to_decimals($number, 'tax_decimals', \NumberFormatter::CURRENCY);
+    }
 }
 
 function to_tax_decimals($number)


### PR DESCRIPTION
Display tax decimals or currency decimals for tax amounts depending on if sales tax is enabled.  This needs to take place for the register, receipt, invoice, and quote.