### PR TITLE
Fix to print 255 character alt item description

### DIFF
--- a/application/views/sales/invoice.php
+++ b/application/views/sales/invoice.php
@@ -125,8 +125,8 @@ $(document).ready(function()
 			?>
 				<tr class="item-row" >
 					<td ></td >
-					<td class="item-description" colspan = "4" ><textarea cols = "6" ><?php echo $item['description']; ?></textarea></td>
-					<td style='text-align:center;'><textarea cols="6"><?php echo $item['serialnumber']; ?></textarea></td>
+					<td class="item-description" colspan = "4" ><div><?php echo $item['description']; ?></div></td>
+					<td style='text-align:center;'><textarea><?php echo $item['serialnumber']; ?></textarea></td>
 				</tr>
 		<?php
 			}

--- a/application/views/sales/quote.php
+++ b/application/views/sales/quote.php
@@ -123,8 +123,8 @@ if (isset($error_message))
 			?>
 			<tr class="item-row">
 				<td></td>
-				<td class="item-name"><textarea cols="6"><?php echo $item['description']; ?></textarea></td>
-				<td style='text-align:center;' colspan="4"><textarea cols="6"><?php echo $item['serialnumber']; ?></textarea></td>
+				<td class="item-name"  colspan = "4"><div><?php echo $item['description']; ?></div></td>
+				<td style='text-align:center;'><textarea><?php echo $item['serialnumber']; ?></textarea></td>
 			</tr>
 		<?php
 			}


### PR DESCRIPTION
Restore the ability to print the entire 255 character alt item description on quote and invoice.