### PR TITLE
Duplicate inserts into ospos_grants cause error

### DIFF
--- a/database/2.3.1_to_2.3.2.sql
+++ b/database/2.3.1_to_2.3.2.sql
@@ -46,9 +46,5 @@ ALTER TABLE `ospos_customers`
 ALTER TABLE `ospos_giftcards`
     MODIFY `person_id` int(10) DEFAULT NULL;
 
-INSERT INTO `ospos_grants` (`permission_id`, `person_id`) VALUES
-('sales_stock', 1),
-('receivings_stock', 1);
-
 ALTER TABLE `ospos_receivings_items`
     ADD COLUMN `receiving_quantity` int(11) NOT NULL DEFAULT '1';


### PR DESCRIPTION
INSERT INTO `ospos_grants` (`permission_id`, `person_id`) VALUES
('sales_stock', 1),
('receivings_stock', 1);

sales_stock and receivings_stock are inserted into the database in 2.3_to_2.3.1.sql, so when this is run it returns an SQL error.