### PR TITLE
add distinct designation to prevent sql error

### DIFF
--- a/database/2.3_migrate_locations.sql
+++ b/database/2.3_migrate_locations.sql
@@ -1,2 +1,2 @@
-INSERT INTO ospos_stock_locations (location_name) (SELECT location FROM ospos_items WHERE NOT EXISTS (select location from ospos_stock_locations where location_name = location));
+INSERT INTO ospos_stock_locations (location_name) (SELECT DISTINCT(location) FROM ospos_items WHERE NOT EXISTS (select location from ospos_stock_locations where location_name = location));
 INSERT INTO ospos_item_quantities (item_id, location_id, quantity) (SELECT item_id, location_id, quantity FROM ospos_items, ospos_stock_locations where ospos_items.location = ospos_stock_locations.location_name);


### PR DESCRIPTION
without distinct it migrates multiple copies of the same stock location name which later cause issues in 2.3_to_2.3.1.sql when trying to insert into ospos_permissions.