### PR TITLE
Removed duplicate lines that exist elsewhere

### DIFF
--- a/database/3.0.2_to_3.1.0.sql
+++ b/database/3.0.2_to_3.1.0.sql
@@ -205,7 +205,6 @@ INSERT IGNORE INTO `ospos_permissions` (`permission_id`, `module_id`) VALUES
 -- add support for cash rounding into config
 
 INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
-('currency_decimals', '2'),
 ('cash_decimals', '2'),
 ('cash_rounding_code', '0');
 
@@ -318,8 +317,6 @@ INSERT INTO `ospos_app_config` (`key`, `value`) VALUES
 ('barcode_quality', '100'),
 ('barcode_type', 'Code39'),
 ('barcode_width', '250'),
-('cash_decimals', '2'),
-('cash_rounding_code', '0'),
 ('receiving_calculate_average_price', '0');
 
 -- replace old tokens in ospos_app_config


### PR DESCRIPTION
('currency_decimals', '2'), exists in 2.4_to_3.0.sql
('cash_decimals', '2'), already exists above
('cash_rounding_code', '0'), already exists above